### PR TITLE
fix: made it so that metrics could be optional in a solo frame

### DIFF
--- a/pysolotools/core/models/solo.py
+++ b/pysolotools/core/models/solo.py
@@ -147,7 +147,7 @@ class Frame:
     frame: int
     sequence: int
     step: int
-    metrics: List[object]
+    metrics: List[dataclass] = field(default_factory=list)
     captures: List[dataclass] = field(default_factory=list)
 
     def __post_init__(self):


### PR DESCRIPTION
It is pretty easy to create a solo dataset without metrics. Made it so that metrics are an optional part of a frame.