### PR TITLE
feat: moved datamodel to factory that allows custom annotations

### DIFF
--- a/pysolotools/core/models/__init__.py
+++ b/pysolotools/core/models/__init__.py
@@ -13,7 +13,6 @@ from .solo import (
     DataFactory,
     DatasetAnnotations,
     DatasetMetadata,
-    DefinitionFactory,
     DepthAnnotation,
     DepthAnnotationDefinition,
     Frame,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,11 @@ from pysolotools.consumers import Solo
 def solo_instance() -> Solo:
     input_data_path = os.path.join(Path(__file__).parents[0], "data", "solo")
     return Solo(data_path=input_data_path)
+
+
+@pytest.fixture(scope="session")
+def solo_custom_data_instance() -> Solo:
+    input_data_path = os.path.join(
+        Path(__file__).parents[0], "data", "solo_custom_type"
+    )
+    return Solo(data_path=input_data_path)

--- a/tests/consumers/test_solo.py
+++ b/tests/consumers/test_solo.py
@@ -1,11 +1,7 @@
 import pytest
 
 from pysolotools.core.iterators import FramesIterator
-from pysolotools.core.models import (
-    AnnotationDefinition,
-    DatasetMetadata,
-    DefinitionFactory,
-)
+from pysolotools.core.models import AnnotationDefinition, DataFactory, DatasetMetadata
 
 
 class TestSolo:
@@ -14,7 +10,7 @@ class TestSolo:
         assert isinstance(metadata, DatasetMetadata)
 
     def test_get_annotation_definitions(self, solo_instance):
-        annotation_def_types = list(DefinitionFactory.switcher.values())
+        annotation_def_types = list(DataFactory.definition_switcher.values())
         annotation_def_types.append(AnnotationDefinition)
         annotation_definition = solo_instance.get_annotation_definitions()
         for ann_def in annotation_definition.annotationDefinitions:

--- a/tests/core/models/test_custom_data.py
+++ b/tests/core/models/test_custom_data.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from pysolotools.core.models import Annotation, AnnotationDefinition, DataFactory
+
+
+@DataFactory.register("type.unity.com/unity.pysolotools.CustomTestType")
+@dataclass
+class CustomTestType(Annotation):
+    int_value: int
+    float_value: float
+    str_value: str
+
+
+@DataFactory.register("type.unity.com/unity.pysolotools.CustomTestType")
+@dataclass
+class CustomTestTypeDefinition(AnnotationDefinition):
+    pass
+
+
+class TestSoloCustomType:
+    def test_get_annotation_definitions(self, solo_custom_data_instance):
+        defs = solo_custom_data_instance.get_annotation_definitions()
+        found = False
+        for d in defs.annotationDefinitions:
+            if isinstance(d, CustomTestTypeDefinition):
+                found = True
+                assert d.id == "custom test type"
+                assert d.description == "Test type."
+        assert found
+
+    def test_frames(self, solo_custom_data_instance):
+        found = False
+        for f in solo_custom_data_instance.frames():
+            caps = f.captures
+            assert len(caps) == 1
+            for c in caps:
+                for a in c.annotations:
+                    if isinstance(a, CustomTestType):
+                        assert not found
+                        found = True
+                        assert a.int_value == 42
+                        assert a.float_value == 0.17
+                        assert a.str_value == "so long"
+        assert found


### PR DESCRIPTION
Modified the data model to allow users to create custom capture, annotation, and annotation definition classes. The user can do this by adding a `DataFactory.register(type_str)` decorator to their class. Updated all of our current data model types to register in the same fashion