### PR TITLE
chore: Replace deprecated Github Actions commands

### DIFF
--- a/.github/workflows/build-docker-image.workflow.yml
+++ b/.github/workflows/build-docker-image.workflow.yml
@@ -38,11 +38,11 @@ jobs:
           if [[ ! -z "$GITHUB_HEAD_REF" ]]
           then
             sha="${{ github.event.pull_request.head.sha }}"
-            echo "::set-output name=ref_name::$(echo ${GITHUB_HEAD_REF##*/})"
-            echo "::set-output name=head_sha::$sha"
+            echo "ref_name=$(echo ${GITHUB_HEAD_REF##*/})" >> $GITHUB_OUTPUT
+            echo "head_sha=$sha" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=ref_name::$(echo ${GITHUB_REF##*/})"
-            echo "::set-output name=head_sha::$GITHUB_SHA"
+            echo "ref_name=$(echo ${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
+            echo "head_sha=$GITHUB_SHA" >> $GITHUB_OUTPUT
           fi
         id: short_names
       - name: Build

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           tag=${{ steps.changelog.outputs.tag }}
           echo "tag $tag"
-          echo "::set-output name=version_tag::${tag}"
+          echo "version_tag=${tag}" >> $GITHUB_OUTPUT
 
   build_and_deploy_docker_image_stg:
     needs: [ changelog ]


### PR DESCRIPTION
Github has recently deprecated the `save-state` and `set-output` commands for Github Actions. This PR replaces
the deprecated command with the newly supported commands.

More information can be found at Github's [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

[_Created by Sourcegraph batch change `danielh/gha-deprecating-state`._](https://sourcegraph.ds.unity3d.com/users/danielh/batch-changes/gha-deprecating-state)